### PR TITLE
Skip yt-dlp postinstall download in Docker build

### DIFF
--- a/client-app/Containerfile
+++ b/client-app/Containerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN YOUTUBE_DL_SKIP_DOWNLOAD=true npm ci
 
 COPY tsconfig.json ./
 COPY src ./src


### PR DESCRIPTION
## Summary

- `youtube-dl-exec` runs a postinstall script that downloads the `yt-dlp` binary from GitHub, which fails on CI due to API rate limiting
- Set `YOUTUBE_DL_SKIP_DOWNLOAD=true` on the `npm ci` step to suppress the download
- The runtime stage already installs yt-dlp via `pip3`, so the postinstall download was redundant

## Test plan

- [ ] Docker build completes without hitting GitHub rate limit
- [ ] Container runs and audio playback works (yt-dlp available via pip install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)