### PR TITLE
Fix test stage: fall back to system yt-dlp when bundled binary absent

### DIFF
--- a/client-app/Containerfile
+++ b/client-app/Containerfile
@@ -1,5 +1,9 @@
 FROM node:22-slim AS build-base
 
+# Tell youtube-dl-exec to use the system yt-dlp (installed via pip in runtime,
+# or resolved from PATH in dev) rather than the bundled binary.
+ENV YOUTUBE_DL_PATH=yt-dlp
+
 # Build native Node modules and compile TypeScript in-container.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \

--- a/client-app/src/services/youtube-service.ts
+++ b/client-app/src/services/youtube-service.ts
@@ -4,10 +4,15 @@ import { spawn } from 'child_process';
 import { createRequire } from 'module';
 import type { ChildProcess } from 'child_process';
 
-// Use the same bundled yt-dlp binary that youtube-dl-exec uses for search,
-// rather than relying on whatever (possibly outdated) version is on PATH.
+// Prefer the bundled binary; fall back to system yt-dlp when the bundled
+// binary wasn't downloaded (e.g. YOUTUBE_DL_SKIP_DOWNLOAD=true in Docker).
 const require = createRequire(import.meta.url);
-const YTDLP_BIN: string = require.resolve('youtube-dl-exec/bin/yt-dlp');
+let YTDLP_BIN: string;
+try {
+  YTDLP_BIN = require.resolve('youtube-dl-exec/bin/yt-dlp');
+} catch {
+  YTDLP_BIN = 'yt-dlp';
+}
 
 export interface YouTubeVideo {
   id: string;


### PR DESCRIPTION
## Summary

Follow-up to #9 — skipping the `youtube-dl-exec` postinstall download broke the test stage because `require.resolve('youtube-dl-exec/bin/yt-dlp')` throws at module load time when the binary was never downloaded.

- **`youtube-service.ts`**: wrap `require.resolve` in try/catch; fall back to `'yt-dlp'` from PATH so the module loads cleanly even when the bundled binary is absent
- **`Containerfile`**: add `ENV YOUTUBE_DL_PATH=yt-dlp` in `build-base` so `youtubedl.exec()` (used by `search()`) also resolves the system binary in both build and runtime stages

## Test plan

- [ ] Docker build test stage passes (no `Cannot find module` error)
- [ ] `search()` and `getAudioStream()` still work at runtime (yt-dlp installed via pip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)