### PR TITLE
cache YouTube search results to avoid repeated yt-dlp searches

### DIFF
--- a/client-app/src/playback-state.ts
+++ b/client-app/src/playback-state.ts
@@ -2,6 +2,7 @@ import { createAudioResource, demuxProbe, AudioPlayerStatus } from '@discordjs/v
 import type { Response } from 'express';
 import { DiscordService } from './services/discord-service.js';
 import { YouTubeService } from './services/youtube-service.js';
+import { YouTubeCache } from './services/youtube-cache.js';
 import type { Playlist, Track } from './services/playlist-service.js';
 
 export interface NowPlayingState {
@@ -32,9 +33,10 @@ export class PlaybackState {
   private pollInterval: ReturnType<typeof setInterval>;
   private advancing = false;
 
-  constructor(discord: DiscordService) {
+  constructor(discord: DiscordService, cachePath?: string) {
     this.discord = discord;
-    this.yt = new YouTubeService();
+    const cache = cachePath ? new YouTubeCache(cachePath) : undefined;
+    this.yt = new YouTubeService(cache);
     this.pollInterval = setInterval(() => this.poll(), 200);
   }
 

--- a/client-app/src/server.ts
+++ b/client-app/src/server.ts
@@ -27,7 +27,8 @@ await discord.init();
 await discord.connectVoice();
 console.log('Discord connected.');
 
-const playback = new PlaybackState(discord);
+const cachePath = path.join(PLAYLIST_FOLDER, 'youtube-cache.json');
+const playback = new PlaybackState(discord, cachePath);
 const app = express();
 app.use(express.json());
 app.use(express.static(publicDir));

--- a/client-app/src/services/youtube-cache.ts
+++ b/client-app/src/services/youtube-cache.ts
@@ -1,0 +1,50 @@
+import { promises as fs } from 'fs';
+import type { YouTubeVideo } from './youtube-service.js';
+
+interface CacheEntry {
+  url: string;
+  title: string;
+  id: string;
+}
+
+interface CacheData {
+  [query: string]: CacheEntry;
+}
+
+export class YouTubeCache {
+  private filePath: string;
+  private data: CacheData = {};
+  private loaded = false;
+
+  constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  private async load(): Promise<void> {
+    if (this.loaded) return;
+    try {
+      const raw = await fs.readFile(this.filePath, 'utf-8');
+      this.data = JSON.parse(raw) as CacheData;
+    } catch {
+      this.data = {};
+    }
+    this.loaded = true;
+  }
+
+  private async persist(): Promise<void> {
+    await fs.writeFile(this.filePath, JSON.stringify(this.data, null, 2));
+  }
+
+  async get(query: string): Promise<YouTubeVideo | null> {
+    await this.load();
+    const entry = this.data[query];
+    if (!entry) return null;
+    return { id: entry.id, title: entry.title, url: entry.url };
+  }
+
+  async set(query: string, video: YouTubeVideo): Promise<void> {
+    await this.load();
+    this.data[query] = { url: video.url, title: video.title, id: video.id };
+    await this.persist();
+  }
+}

--- a/client-app/src/services/youtube-service.ts
+++ b/client-app/src/services/youtube-service.ts
@@ -3,6 +3,7 @@ import { Readable } from 'stream';
 import { spawn } from 'child_process';
 import { createRequire } from 'module';
 import type { ChildProcess } from 'child_process';
+import type { YouTubeCache } from './youtube-cache.js';
 
 // Use the same bundled yt-dlp binary that youtube-dl-exec uses for search,
 // rather than relying on whatever (possibly outdated) version is on PATH.
@@ -17,6 +18,12 @@ export interface YouTubeVideo {
 
 export class YouTubeService {
   private currentProcess?: ChildProcess;
+  private cache?: YouTubeCache;
+
+  constructor(cache?: YouTubeCache) {
+    this.cache = cache;
+  }
+
   /** Ensure yt-dlp binary is installed and on PATH */
   async healthCheck(): Promise<void> {
     try {
@@ -30,9 +37,19 @@ export class YouTubeService {
       throw err;
     }
   }
+
   async search(query: string): Promise<YouTubeVideo | null> {
     // Colons confuse yt-dlp into treating the query as a URL scheme (e.g. "Metamorphosis: Two" → protocol "Metamorphosis:")
     const safeQuery = query.replace(/:/g, ' ');
+
+    if (this.cache) {
+      const cached = await this.cache.get(safeQuery);
+      if (cached) {
+        console.log(`[YouTubeService] cache hit for: "${query}"`);
+        return cached;
+      }
+    }
+
     let results: any;
     try {
         results = await youtubedl.exec(safeQuery, {
@@ -55,11 +72,19 @@ export class YouTubeService {
       return null;
     }
     const video = parsedResults.entries[0];
-    return {
+    const result: YouTubeVideo = {
       id: video.id ?? '',
       title: video.title ?? '',
       url: video.webpage_url ?? ''
     };
+
+    if (this.cache) {
+      await this.cache.set(safeQuery, result).catch(err =>
+        console.warn(`[YouTubeService] failed to write cache:`, err)
+      );
+    }
+
+    return result;
   }
 
   async getAudioStream(url: string): Promise<Readable> {
@@ -99,6 +124,7 @@ export class YouTubeService {
       this.currentProcess = undefined;
     }
   }
+
   /** Cleanup the YouTubeService, cancelling any active process */
   public destroy(): void {
     this.cancelStream();

--- a/client-app/tests/services/youtube-cache.test.ts
+++ b/client-app/tests/services/youtube-cache.test.ts
@@ -1,0 +1,56 @@
+import { jest } from '@jest/globals';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('YouTubeCache', () => {
+  let tmpDir: string;
+  let cacheFile: string;
+  let YouTubeCache: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'yt-cache-test-'));
+    cacheFile = path.join(tmpDir, 'youtube-cache.json');
+    ({ YouTubeCache } = await import('../../src/services/youtube-cache.js'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns null for a cache miss', async () => {
+    const cache = new YouTubeCache(cacheFile);
+    expect(await cache.get('some query')).toBeNull();
+  });
+
+  it('returns the stored video after set()', async () => {
+    const cache = new YouTubeCache(cacheFile);
+    const video = { id: 'abc123', title: 'Cool Track', url: 'https://www.youtube.com/watch?v=abc123' };
+    await cache.set('cool track artist', video);
+    expect(await cache.get('cool track artist')).toEqual(video);
+  });
+
+  it('persists across instances (survives restart)', async () => {
+    const video = { id: 'xyz', title: 'Persisted', url: 'https://www.youtube.com/watch?v=xyz' };
+    const cache1 = new YouTubeCache(cacheFile);
+    await cache1.set('persistent query', video);
+
+    const cache2 = new YouTubeCache(cacheFile);
+    expect(await cache2.get('persistent query')).toEqual(video);
+  });
+
+  it('returns null when the cache file does not exist', async () => {
+    const cache = new YouTubeCache(path.join(tmpDir, 'nonexistent.json'));
+    expect(await cache.get('anything')).toBeNull();
+  });
+
+  it('overwrites an existing entry', async () => {
+    const cache = new YouTubeCache(cacheFile);
+    const v1 = { id: 'old', title: 'Old', url: 'https://www.youtube.com/watch?v=old' };
+    const v2 = { id: 'new', title: 'New', url: 'https://www.youtube.com/watch?v=new' };
+    await cache.set('same query', v1);
+    await cache.set('same query', v2);
+    expect(await cache.get('same query')).toEqual(v2);
+  });
+});


### PR DESCRIPTION
Adds YouTubeCache (JSON file on disk) so a track's YouTube URL is only searched once — subsequent plays read from cache, cutting per-track startup latency to near-zero for repeated moods.