### PR TITLE
soundboard redesign: mode picker, four fixed moods, local audio strea…

### DIFF
--- a/client-app/src/playback-state.ts
+++ b/client-app/src/playback-state.ts
@@ -91,6 +91,28 @@ export class PlaybackState {
     }
   }
 
+  resetDiscordPlayback(): void {
+    this.prevPlayerStatus = undefined;
+    this.advancing = true;   // block poll-loop advance while tearing down
+    this.playlist = null;
+    this.tracks = [];
+    this.advancing = false;
+    this.broadcast();
+  }
+
+  async loadLocalMode(playlist: Playlist): Promise<void> {
+    this.playlist = playlist;
+    this.tracks = shuffle(playlist.tracks);
+    this.currentIndex = 0;
+    this.broadcast();
+  }
+
+  skipLocalMode(): void {
+    if (!this.tracks.length) return;
+    this.currentIndex = (this.currentIndex + 1) % this.tracks.length;
+    this.broadcast();
+  }
+
   pause(): void {
     if (!this.playlist) throw new Error('No active playlist');
     this.discord.pause();

--- a/client-app/src/public/app.js
+++ b/client-app/src/public/app.js
@@ -1,33 +1,71 @@
-const grid = document.getElementById('mood-grid');
-const emptyMsg = document.getElementById('empty-msg');
+const modePicker      = document.getElementById('mode-picker');
+const modeChip        = document.getElementById('mode-chip');
 const nowPlayingLabel = document.getElementById('now-playing-label');
 const nowPlayingTrack = document.getElementById('now-playing-track');
-const btnPauseResume = document.getElementById('btn-pause-resume');
-const btnSkip = document.getElementById('btn-skip');
+const btnPauseResume  = document.getElementById('btn-pause-resume');
+const btnSkip         = document.getElementById('btn-skip');
+const localAudio      = document.getElementById('local-audio');
 
+const STORAGE_KEY = 'playback-mode';
+let activeMode = null;
 let paused = false;
 let activePlaylistName = null;
 
-// --- Render mood buttons ---
+// --- Mode picker ---
 
-async function loadPlaylists() {
-  const res = await fetch('/playlists');
-  const items = await res.json();
-  grid.querySelectorAll('.mood-btn').forEach(b => b.remove());
-  if (items.length === 0) {
-    emptyMsg.hidden = false;
-    return;
-  }
-  emptyMsg.hidden = true;
-  for (const item of items) {
-    const btn = document.createElement('button');
-    btn.className = 'mood-btn';
-    btn.dataset.name = item.name;
-    btn.innerHTML = `${item.name}<span class="track-count">${item.trackCount} tracks</span>`;
-    btn.addEventListener('click', () => playPlaylist(item.name));
-    grid.appendChild(btn);
+function showSoundboard(mode, animate = true) {
+  activeMode = mode;
+  modeChip.textContent = mode === 'local' ? 'Local Audio' : 'Discord Bot';
+  if (animate) {
+    modePicker.classList.add('dismissed');
+  } else {
+    modePicker.style.display = 'none';
   }
 }
+
+const savedMode = sessionStorage.getItem(STORAGE_KEY);
+if (savedMode) {
+  showSoundboard(savedMode, false);
+}
+
+modeChip.addEventListener('click', async () => {
+  if (activeMode === 'discord') {
+    await fetch('/disconnect-discord', { method: 'POST' });
+  } else if (activeMode === 'local') {
+    localAudio.pause();
+    localAudio.src = '';
+  }
+  sessionStorage.removeItem(STORAGE_KEY);
+  activeMode = null;
+  modePicker.style.display = '';
+  modePicker.classList.remove('dismissed');
+});
+
+document.querySelectorAll('.mode-opt-btn').forEach(btn => {
+  btn.addEventListener('click', async () => {
+    const mode = btn.dataset.mode;
+
+    if (mode === 'discord') {
+      const label = btn.querySelector('.mode-opt-label');
+      const orig = label.textContent;
+      label.textContent = 'Connecting…';
+      btn.disabled = true;
+      try {
+        const res = await fetch('/connect-discord', { method: 'POST' });
+        if (!res.ok) throw new Error('connect failed');
+      } catch {
+        label.textContent = orig;
+        btn.disabled = false;
+        return;
+      }
+    }
+
+    sessionStorage.setItem(STORAGE_KEY, mode);
+    showSoundboard(mode, true);
+  });
+});
+
+// --- Mood buttons ---
 
 function setActiveButton(name) {
   document.querySelectorAll('.mood-btn').forEach(btn => {
@@ -35,21 +73,64 @@ function setActiveButton(name) {
   });
 }
 
-// --- Playback controls ---
-
-async function playPlaylist(name) {
-  await fetch(`/play/${encodeURIComponent(name)}`, { method: 'POST' });
+function flashError(name) {
+  const btn = document.querySelector(`.mood-btn[data-name="${name}"]`);
+  if (!btn) return;
+  btn.classList.remove('error');
+  void btn.offsetWidth;
+  btn.classList.add('error');
+  btn.addEventListener('animationend', () => btn.classList.remove('error'), { once: true });
 }
 
-btnPauseResume.addEventListener('click', async () => {
-  if (paused) {
-    await fetch('/resume', { method: 'POST' });
+async function playPlaylist(name) {
+  if (activeMode === 'local') {
+    localAudio.src = `/stream/${encodeURIComponent(name)}`;
+    try {
+      await localAudio.play();
+    } catch {
+      flashError(name);
+    }
   } else {
-    await fetch('/pause', { method: 'POST' });
+    const res = await fetch(`/play/${encodeURIComponent(name)}`, { method: 'POST' });
+    if (!res.ok) flashError(name);
+  }
+}
+
+document.querySelectorAll('.mood-btn').forEach(btn => {
+  btn.addEventListener('click', () => playPlaylist(btn.dataset.name));
+});
+
+// --- Playback controls ---
+
+btnPauseResume.addEventListener('click', async () => {
+  if (activeMode === 'local') {
+    if (paused) {
+      await localAudio.play();
+    } else {
+      localAudio.pause();
+    }
+    paused = !paused;
+    btnPauseResume.textContent = paused ? '▶' : '⏸';
+  } else {
+    if (paused) {
+      await fetch('/resume', { method: 'POST' });
+    } else {
+      await fetch('/pause', { method: 'POST' });
+    }
   }
 });
 
-btnSkip.addEventListener('click', () => fetch('/skip', { method: 'POST' }));
+btnSkip.addEventListener('click', async () => {
+  if (activeMode === 'local') {
+    await fetch('/skip?local=1', { method: 'POST' });
+    if (activePlaylistName) {
+      localAudio.src = `/stream/${encodeURIComponent(activePlaylistName)}`;
+      try { await localAudio.play(); } catch { /* ignore */ }
+    }
+  } else {
+    await fetch('/skip', { method: 'POST' });
+  }
+});
 
 // --- SSE status updates ---
 
@@ -59,9 +140,7 @@ function connectSSE() {
     const state = JSON.parse(e.data);
     updateUI(state);
   };
-  es.onerror = () => {
-    // EventSource reconnects automatically
-  };
+  es.onerror = () => {};
 }
 
 function updateUI(state) {
@@ -76,9 +155,12 @@ function updateUI(state) {
     return;
   }
 
-  const isPlaying = state.playerStatus === 'playing';
   const isPaused = state.playerStatus === 'paused';
-  paused = isPaused;
+
+  if (activeMode !== 'local') {
+    paused = isPaused;
+    btnPauseResume.textContent = isPaused ? '▶' : '⏸';
+  }
 
   const trackNum = `${state.trackIndex + 1}/${state.totalTracks}`;
   nowPlayingLabel.textContent = `${state.playlistName}  ·  ${trackNum}`;
@@ -94,10 +176,8 @@ function updateUI(state) {
 
   btnPauseResume.hidden = false;
   btnSkip.hidden = false;
-  btnPauseResume.textContent = isPaused ? '▶' : '⏸';
 }
 
 // --- Init ---
 
-loadPlaylists();
 connectSSE();

--- a/client-app/src/public/index.html
+++ b/client-app/src/public/index.html
@@ -7,15 +7,39 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+
+  <!-- Fixed full-screen overlay — covers the soundboard until a mode is chosen -->
+  <div id="mode-picker" class="mode-picker">
+    <div class="mode-picker-inner">
+      <h1 class="mode-picker-title">Soundboard</h1>
+      <p class="mode-picker-sub">How are you playing tonight?</p>
+      <div class="mode-options">
+        <button class="mode-opt-btn" data-mode="local">
+          <span class="mode-opt-icon">🔊</span>
+          <span class="mode-opt-label">Local Audio</span>
+          <span class="mode-opt-desc">Bluetooth speaker or device</span>
+        </button>
+        <button class="mode-opt-btn" data-mode="discord">
+          <span class="mode-opt-icon">🎮</span>
+          <span class="mode-opt-label">Discord Bot</span>
+          <span class="mode-opt-desc">Stream to voice channel</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Soundboard — always in DOM, revealed when mode picker dismisses -->
   <header>
     <h1>Soundboard</h1>
+    <span id="mode-chip" class="mode-chip"></span>
   </header>
 
   <main>
-    <div id="mood-grid" class="mood-grid">
-      <p class="empty-msg" id="empty-msg" hidden>
-        No playlists found. Add JSON playlist files to your playlists directory.
-      </p>
+    <div class="mood-grid">
+      <button class="mood-btn" data-name="Ambient">Ambient</button>
+      <button class="mood-btn" data-name="Action">Action</button>
+      <button class="mood-btn" data-name="Foreboding">Foreboding</button>
+      <button class="mood-btn" data-name="Triumphant">Triumphant</button>
     </div>
   </main>
 
@@ -30,6 +54,7 @@
     </div>
   </footer>
 
+  <audio id="local-audio"></audio>
   <script src="app.js"></script>
 </body>
 </html>

--- a/client-app/src/public/style.css
+++ b/client-app/src/public/style.css
@@ -22,12 +22,104 @@ body {
   color: var(--text);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   min-height: 100dvh;
+}
+
+/* ── Mode picker ─────────────────────────────────────── */
+
+.mode-picker {
+  align-items: center;
+  background: var(--bg);
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  padding: 2rem 1.25rem;
+  position: fixed;
+  right: 0;
+  top: 0;
+  transition: opacity 0.25s ease;
+  z-index: 999;
+}
+
+.mode-picker.dismissed {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.mode-picker-inner {
+  max-width: 420px;
+  text-align: center;
+  width: 100%;
+}
+
+.mode-picker-title {
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  margin-bottom: 0.5rem;
+  text-transform: uppercase;
+}
+
+.mode-picker-sub {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 2rem;
+}
+
+.mode-options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.mode-opt-btn {
+  align-items: center;
+  background: var(--surface);
+  border: 2px solid var(--surface-2);
+  border-radius: 16px;
+  color: var(--text);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-height: 120px;
+  padding: 1.5rem 1rem;
+  transition: border-color 0.15s, background 0.15s;
+  width: 100%;
+}
+
+.mode-opt-btn:active {
+  background: var(--surface-2);
+  border-color: var(--accent);
+}
+
+.mode-opt-icon {
+  font-size: 2rem;
+  line-height: 1;
+}
+
+.mode-opt-label {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.mode-opt-desc {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+}
+
+/* ── Soundboard ──────────────────────────────────────── */
+
+body {
   padding-bottom: var(--footer-height);
 }
 
 header {
-  padding: 1rem 1.25rem 0.5rem;
+  align-items: center;
   border-bottom: 1px solid var(--surface-2);
+  display: flex;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem 0.5rem;
 }
 
 header h1 {
@@ -38,26 +130,34 @@ header h1 {
   text-transform: uppercase;
 }
 
+.mode-chip {
+  background: var(--surface-2);
+  border-radius: 999px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.6rem;
+  text-transform: uppercase;
+  transition: background 0.15s, color 0.15s;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mode-chip:hover {
+  background: var(--accent);
+  color: var(--text);
+}
+
 main {
   padding: 1rem;
 }
 
+/* Fixed 2×2 grid */
 .mood-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.75rem;
-}
-
-@media (min-width: 480px) {
-  .mood-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (min-width: 720px) {
-  .mood-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
 }
 
 .mood-btn {
@@ -66,14 +166,14 @@ main {
   border-radius: 12px;
   color: var(--text);
   cursor: pointer;
-  font-size: 1rem;
-  font-weight: 500;
-  min-height: 72px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  min-height: 120px;
   padding: 1rem 0.75rem;
   text-align: center;
   transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
   width: 100%;
-  word-break: break-word;
 }
 
 .mood-btn:active {
@@ -86,22 +186,17 @@ main {
   background: var(--surface-2);
 }
 
-.mood-btn .track-count {
-  display: block;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  margin-top: 0.25rem;
+.mood-btn.error {
+  animation: error-flash 0.4s ease;
 }
 
-.empty-msg {
-  color: var(--text-muted);
-  font-size: 0.9rem;
-  grid-column: 1 / -1;
-  padding: 2rem 0;
-  text-align: center;
+@keyframes error-flash {
+  0%, 100% { border-color: transparent; background: var(--surface); }
+  40%, 60% { border-color: var(--accent); background: rgba(233, 69, 96, 0.15); }
 }
 
-/* Now-playing footer */
+/* ── Now-playing footer ──────────────────────────────── */
+
 footer#now-playing {
   align-items: center;
   background: var(--surface);

--- a/client-app/src/server.ts
+++ b/client-app/src/server.ts
@@ -5,12 +5,14 @@ import path from 'path';
 import { DiscordService } from './services/discord-service.js';
 import { PlaylistService } from './services/playlist-service.js';
 import { PlaybackState } from './playback-state.js';
+import { YouTubeService } from './services/youtube-service.js';
 import { PLAYLIST_FOLDER } from './config.js';
 
 const token = process.env['DISCORD_TOKEN'];
 const channelId = process.env['DISCORD_VOICE_CHANNEL_ID'];
 
 if (!token || !channelId) {
+  console.error('Missing required environment variables: DISCORD_TOKEN and DISCORD_VOICE_CHANNEL_ID');
   process.exit(1);
 }
 
@@ -20,12 +22,11 @@ const PORT = parseInt(process.env['PORT'] ?? '3000', 10);
 
 const discord = new DiscordService(token, channelId);
 const playlists = new PlaylistService(PLAYLIST_FOLDER);
-
-await discord.init();
-await discord.connectVoice();
-
 const cachePath = path.join(PLAYLIST_FOLDER, 'youtube-cache.json');
 const playback = new PlaybackState(discord, cachePath);
+const localYt = new YouTubeService();
+let discordLoggedIn = false;
+let discordVoiceConnected = false;
 const app = express();
 app.use(express.json());
 app.use(express.static(publicDir));
@@ -42,6 +43,29 @@ async function findPlaylist(name: string) {
 }
 
 // --- Routes ---
+
+app.post('/connect-discord', async (_req, res) => {
+  try {
+    if (!discordLoggedIn) {
+      await discord.connect();
+      await discord.init();
+      discordLoggedIn = true;
+    }
+    if (!discordVoiceConnected) {
+      await discord.connectVoice();
+      discordVoiceConnected = true;
+    }
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: String(err.message ?? err) });
+  }
+});
+
+app.post('/disconnect-discord', (_req, res) => {
+  discord.disconnectVoice();
+  discordVoiceConnected = false;
+  res.json({ ok: true });
+});
 
 app.get('/playlists', async (_req, res) => {
   const files = await playlists.getPlaylists();
@@ -82,13 +106,55 @@ app.post('/resume', (_req, res) => {
   res.json({ ok: true });
 });
 
-app.post('/skip', async (_req, res) => {
+app.post('/skip', async (req, res) => {
   if (!playback.isActive()) {
     res.status(409).json({ error: 'No active playlist' });
     return;
   }
-  await playback.skip();
+  if (req.query['local'] === '1') {
+    playback.skipLocalMode();
+  } else {
+    await playback.skip();
+  }
   res.json({ ok: true });
+});
+
+app.get('/stream/:name', async (req, res) => {
+  const playlist = await findPlaylist(req.params['name']!);
+  if (!playlist) {
+    res.status(404).json({ error: `Playlist "${req.params['name']}" not found` });
+    return;
+  }
+
+  // Kill any existing local stream process
+  localYt.cancelStream();
+
+  // Load playlist in local mode if it changed
+  const state = playback.getState();
+  if (state.playlistName !== playlist.name) {
+    await playback.loadLocalMode(playlist);
+  }
+
+  const track = playback.getState().track;
+  if (!track) {
+    res.status(503).json({ error: 'No track available' });
+    return;
+  }
+
+  try {
+    const query = `${track.name} ${track.artists.join(' ')}`;
+    const video = await localYt.search(query);
+    if (!video) {
+      res.status(404).json({ error: 'No YouTube result for track' });
+      return;
+    }
+    const stream = await localYt.getAudioStream(video.url);
+    res.setHeader('Content-Type', 'audio/webm');
+    stream.pipe(res);
+    req.on('close', () => localYt.cancelStream());
+  } catch {
+    if (!res.headersSent) res.status(500).json({ error: 'Failed to stream audio' });
+  }
 });
 
 app.get('/debug', (_req, res) => {
@@ -118,6 +184,7 @@ const server = app.listen(PORT);
 
 process.on('SIGTERM', () => {
   playback.destroy();
+  localYt.destroy();
   discord.destroy();
   server.close(() => process.exit(0));
 });

--- a/client-app/src/services/discord-service.ts
+++ b/client-app/src/services/discord-service.ts
@@ -5,17 +5,21 @@ export class DiscordService {
   private lastPlayerStatus?: AudioPlayerStatus;
   private client: Client;
   private player?: AudioPlayer;
+  private token: string;
   private channelId: string;
   private guildId?: string;
 
   constructor(token: string, channelId: string) {
+    this.token = token;
     this.client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates] });
     this.channelId = channelId;
-    this.client.login(token);
+  }
+
+  async connect(): Promise<void> {
+    await this.client.login(this.token);
   }
 
   async init(): Promise<void> {
-    // wait for the Discord client to be ready
     await new Promise<void>(resolve => this.client.once('clientReady', () => resolve()));
   }
 
@@ -115,6 +119,21 @@ export class DiscordService {
   /** Stop the current audio resource */
   public stop(): void {
     this.player?.stop();
+  }
+
+  /** Leave the voice channel without destroying the Discord client */
+  public disconnectVoice(): void {
+    const conn = this.getVoiceConnection();
+    this.guildId = undefined;          // clear first so getVoiceConnection returns undefined elsewhere
+    this.lastPlayerStatus = undefined;
+    this.player?.stop();
+    this.player = undefined;
+    try {
+      conn?.disconnect();              // sends channel_id: null to Discord gateway
+      conn?.destroy();                 // cleans up internal state
+    } catch {
+      // already destroyed or adapter unavailable
+    }
   }
 
   destroy(): void {

--- a/client-app/tests/services/playback-state.test.ts
+++ b/client-app/tests/services/playback-state.test.ts
@@ -1,0 +1,118 @@
+import { jest } from '@jest/globals';
+import { Readable } from 'stream';
+
+// Minimal Discord service mock
+const mockDiscord = {
+  getPlayerStatus: jest.fn().mockReturnValue(undefined),
+  stop: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+  playNow: jest.fn(),
+};
+
+// yt-dlp mock so YouTubeService doesn't spawn real processes
+const mockStdout = new Readable({ read() {} });
+const mockStderr = new Readable({ read() {} });
+const mockProcess = {
+  stdout: mockStdout,
+  stderr: mockStderr,
+  on: jest.fn().mockReturnThis(),
+  kill: jest.fn(),
+  killed: false,
+};
+
+jest.unstable_mockModule('child_process', () => ({
+  spawn: jest.fn(() => mockProcess),
+}));
+
+const mockYtExec = jest.fn();
+jest.unstable_mockModule('youtube-dl-exec', () => ({
+  default: Object.assign(jest.fn(), { exec: mockYtExec }),
+}));
+
+const testPlaylist = {
+  name: 'Ambient',
+  tracks: [
+    { name: 'Track A', artists: ['Artist 1'] },
+    { name: 'Track B', artists: ['Artist 2'] },
+    { name: 'Track C', artists: ['Artist 3'] },
+  ],
+};
+
+describe('PlaybackState — local mode methods', () => {
+  let PlaybackState: any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    mockProcess.on = jest.fn().mockReturnThis();
+    (mockStdout as any).on = jest.fn().mockReturnThis();
+    (mockStderr as any).on = jest.fn().mockReturnThis();
+    ({ PlaybackState } = await import('../../src/playback-state.js'));
+  });
+
+  describe('loadLocalMode', () => {
+    it('sets the active playlist without touching Discord', async () => {
+      const state = new PlaybackState(mockDiscord as any);
+      await state.loadLocalMode(testPlaylist);
+
+      expect(mockDiscord.stop).not.toHaveBeenCalled();
+      expect(mockDiscord.playNow).not.toHaveBeenCalled();
+      expect(state.isActive()).toBe(true);
+    });
+
+    it('resets track index to 0', async () => {
+      const state = new PlaybackState(mockDiscord as any);
+      await state.loadLocalMode(testPlaylist);
+
+      const nowPlaying = state.getState();
+      expect(nowPlaying.trackIndex).toBe(0);
+      expect(nowPlaying.totalTracks).toBe(testPlaylist.tracks.length);
+      expect(nowPlaying.playlistName).toBe('Ambient');
+    });
+
+    it('broadcasts SSE state after loading', async () => {
+      const state = new PlaybackState(mockDiscord as any);
+      const broadcasts: any[] = [];
+      state.addSSEClient({ write: (d: string) => broadcasts.push(JSON.parse(d.replace('data: ', ''))) } as any);
+
+      await state.loadLocalMode(testPlaylist);
+
+      const last = broadcasts[broadcasts.length - 1];
+      expect(last.playlistName).toBe('Ambient');
+    });
+  });
+
+  describe('skipLocalMode', () => {
+    it('advances track index without Discord playback', async () => {
+      const state = new PlaybackState(mockDiscord as any);
+      await state.loadLocalMode(testPlaylist);
+      const before = state.getState().trackIndex;
+
+      state.skipLocalMode();
+
+      expect(state.getState().trackIndex).toBe((before + 1) % testPlaylist.tracks.length);
+      expect(mockDiscord.playNow).not.toHaveBeenCalled();
+    });
+
+    it('wraps around to 0 after the last track', async () => {
+      const state = new PlaybackState(mockDiscord as any);
+      const single = { name: 'Solo', tracks: [{ name: 'Only Track', artists: [] }] };
+      await state.loadLocalMode(single);
+
+      state.skipLocalMode();
+
+      expect(state.getState().trackIndex).toBe(0);
+    });
+
+    it('broadcasts SSE on skip', async () => {
+      const state = new PlaybackState(mockDiscord as any);
+      await state.loadLocalMode(testPlaylist);
+      const broadcasts: any[] = [];
+      state.addSSEClient({ write: (d: string) => broadcasts.push(JSON.parse(d.replace('data: ', ''))) } as any);
+
+      state.skipLocalMode();
+
+      expect(broadcasts.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/openspec/changes/archive/2026-05-22-soundboard-redesign/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-22-soundboard-redesign/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/archive/2026-05-22-soundboard-redesign/design.md
+++ b/openspec/changes/archive/2026-05-22-soundboard-redesign/design.md
@@ -1,0 +1,54 @@
+## Context
+
+The soundboard is a TypeScript/Express server that streams audio to Discord via yt-dlp. The frontend is vanilla JS/CSS served as static files. The existing `PlaybackState` and `DiscordService` handle all playback; there is no concept of playback mode or browser-side audio.
+
+The user runs sessions on a Victorian cyberpunk campaign and wants to play audio either through Discord (remote players) or directly to a local Bluetooth speaker (in-person play). These are mutually exclusive modes chosen once per session at load time.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Mode picker screen before the soundboard appears (Local Audio or Discord Bot)
+- Four fixed mood buttons replacing the dynamic playlist grid
+- Local audio mode: browser plays audio via an `<audio>` element fed by a server streaming endpoint
+- Discord mode: unchanged existing behaviour
+
+**Non-Goals:**
+- Switching modes mid-session without a page reload
+- Volume control
+- Simultaneous Local + Discord output
+- Any change to how playlists are stored or discovered on disk
+
+## Decisions
+
+### Four hardcoded buttons vs. dynamic grid
+
+The four moods (Ambient, Action, Foreboding, Triumphant) are fixed in the UI rather than loaded from `/playlists`. The server still reads playlist files from disk, but the frontend maps each button to a well-known name. This removes the complexity of the DM seeing a scrambled or partial grid when playlist files are misnamed.
+
+**Alternative considered**: Keep the dynamic grid, just enforce naming by convention. Rejected because it silently degrades — a misnamed file simply doesn't show up, and there's no clear "home base" layout at a glance.
+
+### Local audio: server-side streaming vs. client-side URL passthrough
+
+The server pipes yt-dlp output as a chunked HTTP audio stream (`/stream/:name`) rather than returning a YouTube URL for the browser to fetch directly.
+
+**Alternative considered**: Return the YouTube direct URL and let the browser `<audio>` element fetch it. Rejected because YouTube's CDN URLs are short-lived, IP-bound, and increasingly bot-detected — browser playback of raw YouTube URLs is unreliable.
+
+### Mode stored in sessionStorage, not server state
+
+The chosen mode (local/discord) is stored in the browser's `sessionStorage`. The server is stateless with respect to mode — in Local Audio mode the browser calls `/stream/:name`; in Discord mode it calls `/play/:name`. No server-side session or mode flag needed.
+
+**Alternative considered**: Server-side mode flag toggled by an endpoint. Rejected — adds server state for a purely client-routing concern, and breaks if two browsers are open simultaneously.
+
+### Local audio streaming endpoint
+
+`GET /stream/:name` starts yt-dlp for the named playlist's current track and pipes stdout directly to the HTTP response with `Content-Type: audio/webm`. The browser `<audio>` element consumes this stream. Skip/pause/resume in local mode are handled by the browser's native audio API (pause, currentTime manipulation) rather than server endpoints.
+
+## Risks / Trade-offs
+
+- **yt-dlp stream latency** → First audio may take 2-4s to begin in local mode. Mitigation: show a loading state on the active button.
+- **Concurrent stream requests** → If the user taps a new mood before the previous stream closes, two yt-dlp processes run briefly. Mitigation: server tracks and kills the previous stream process on new `/stream` request.
+- **Local mode skip/resume divergence** → Local mode skip is browser-native; Discord mode skip calls `/skip`. The UI must hide/show the correct controls per mode.
+- **No progress indicator** → Neither mode exposes track progress position. Accepted for now.
+
+## Migration Plan
+
+No migration needed. Existing playlist JSON files continue to work. The four button names (Ambient, Action, Foreboding, Triumphant) must match `name` fields in playlist JSONs — this is a naming convention, not a schema change.

--- a/openspec/changes/archive/2026-05-22-soundboard-redesign/proposal.md
+++ b/openspec/changes/archive/2026-05-22-soundboard-redesign/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The soundboard currently assumes Discord-only playback and presents a dynamic grid of whatever playlist files exist — neither fits how the tool is actually used. Sessions need a consistent set of four mood categories (Ambient, Action, Foreboding, Triumphant) and the option to play audio locally through a Bluetooth speaker instead of routing it through the Discord bot.
+
+## What Changes
+
+- On page load, a mode picker lets the user choose **Local Audio** (browser streams audio directly to device/Bluetooth) or **Discord Bot** (existing behaviour)
+- The mood grid is replaced with four fixed large buttons: **Ambient**, **Action**, **Foreboding**, **Triumphant**
+- A new server endpoint streams yt-dlp audio as an HTTP audio stream for local playback mode
+- The now-playing strip and playback controls remain, adapting to whichever mode is active
+
+## Capabilities
+
+### New Capabilities
+- `audio-mode-selection`: Mode picker screen shown on load; user chooses Local Audio or Discord Bot before the soundboard appears
+- `local-audio-playback`: Server streams track audio as HTTP chunked audio for browser `<audio>` element playback; used in Local Audio mode
+
+### Modified Capabilities
+- `soundboard-ui`: Mood grid replaced with four fixed buttons (Ambient, Action, Foreboding, Triumphant); playlist JSON files are expected to use these four names
+
+## Impact
+
+- `src/public/index.html`, `src/public/app.js`, `src/public/style.css` — UI rewrite
+- `src/server.ts` — new `/stream/:name` endpoint for local audio
+- `src/playback-state.ts` — mode-aware playback (Discord vs local)
+- Playlist JSON files must be named/contain `name` matching one of the four categories
+- No change to Discord integration when running in Discord mode

--- a/openspec/changes/archive/2026-05-22-soundboard-redesign/specs/audio-mode-selection/spec.md
+++ b/openspec/changes/archive/2026-05-22-soundboard-redesign/specs/audio-mode-selection/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Mode picker shown on first load
+The UI SHALL display a full-screen mode picker before the soundboard when no mode has been selected in the current session.
+
+#### Scenario: Fresh page load
+- **WHEN** the page loads and no mode is stored in sessionStorage
+- **THEN** a mode picker screen is shown with two options: "Local Audio" and "Discord Bot"; the soundboard grid is not visible
+
+#### Scenario: Mode already selected
+- **WHEN** the page loads and a mode is stored in sessionStorage
+- **THEN** the mode picker is skipped and the soundboard is shown immediately
+
+### Requirement: User selects a mode
+The UI SHALL store the chosen mode and transition to the soundboard without a page reload.
+
+#### Scenario: Select Local Audio
+- **WHEN** the user taps "Local Audio"
+- **THEN** `local` is stored in sessionStorage under the key `playback-mode`, and the soundboard view replaces the mode picker
+
+#### Scenario: Select Discord Bot
+- **WHEN** the user taps "Discord Bot"
+- **THEN** `discord` is stored in sessionStorage under the key `playback-mode`, and the soundboard view replaces the mode picker
+
+### Requirement: Mode is visible in the soundboard
+The UI SHALL indicate the active mode somewhere in the soundboard so the user can confirm which mode is running.
+
+#### Scenario: Mode label displayed
+- **WHEN** the soundboard is visible
+- **THEN** a small label shows either "Local Audio" or "Discord Bot" indicating the current mode

--- a/openspec/changes/archive/2026-05-22-soundboard-redesign/specs/local-audio-playback/spec.md
+++ b/openspec/changes/archive/2026-05-22-soundboard-redesign/specs/local-audio-playback/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Server streams track audio over HTTP
+The server SHALL expose `GET /stream/:name` that pipes yt-dlp audio output for the named playlist's current track as a chunked HTTP response.
+
+#### Scenario: Valid playlist name
+- **WHEN** `GET /stream/:name` is requested with a known playlist name
+- **THEN** the server responds with `Content-Type: audio/webm`, status 200, and streams audio data until the track ends or the connection closes
+
+#### Scenario: Unknown playlist name
+- **WHEN** `GET /stream/:name` is requested with an unknown playlist name
+- **THEN** the server responds with status 404
+
+#### Scenario: New stream requested while one is active
+- **WHEN** a `/stream/:name` request arrives while a previous stream process is running
+- **THEN** the previous yt-dlp process is killed and a new stream begins for the new request
+
+### Requirement: Browser plays audio via native audio element in Local Audio mode
+In Local Audio mode, the UI SHALL use an `<audio>` element pointed at `/stream/:name` rather than calling `/play/:name`.
+
+#### Scenario: Tap mood button in Local Audio mode
+- **WHEN** the user taps a mood button and the active mode is Local Audio
+- **THEN** the browser sets the `<audio>` element's `src` to `/stream/:name` and calls `.play()`; no request is sent to `/play/:name`
+
+#### Scenario: Tap mood button in Discord mode
+- **WHEN** the user taps a mood button and the active mode is Discord
+- **THEN** `POST /play/:name` is sent as before; the `<audio>` element is not used
+
+### Requirement: Playback controls adapt to Local Audio mode
+In Local Audio mode, pause and resume SHALL use the browser's native audio API; skip SHALL request a new stream for the same playlist.
+
+#### Scenario: Pause in Local Audio mode
+- **WHEN** the user taps Pause and the active mode is Local Audio
+- **THEN** `audio.pause()` is called; no request is sent to `/pause`
+
+#### Scenario: Resume in Local Audio mode
+- **WHEN** the user taps Resume and the active mode is Local Audio
+- **THEN** `audio.play()` is called; no request is sent to `/resume`
+
+#### Scenario: Skip in Local Audio mode
+- **WHEN** the user taps Skip and the active mode is Local Audio
+- **THEN** `POST /skip` is sent to advance the server's track index, then the `<audio>` src is refreshed to `/stream/:name` to start the next track

--- a/openspec/changes/archive/2026-05-22-soundboard-redesign/specs/soundboard-ui/spec.md
+++ b/openspec/changes/archive/2026-05-22-soundboard-redesign/specs/soundboard-ui/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: Mood grid displays four fixed mood buttons
+The UI SHALL display exactly four fixed mood buttons — Ambient, Action, Foreboding, Triumphant — arranged in a 2×2 grid, regardless of what playlist files exist on disk.
+
+#### Scenario: Page loaded with mode selected
+- **WHEN** the soundboard view is shown after mode selection
+- **THEN** four large buttons are displayed: Ambient, Action, Foreboding, Triumphant; no dynamic loading from `/playlists` is required to render the grid
+
+#### Scenario: Missing playlist file
+- **WHEN** a mood button is tapped but no playlist JSON with a matching `name` exists on disk
+- **THEN** the server returns an error and the UI shows a brief error state on that button (e.g., red flash); the button does not disappear
+
+## REMOVED Requirements
+
+### Requirement: Mood grid displays all available playlists
+**Reason**: Replaced by four fixed mood buttons. The dynamic grid that loaded all playlist files and rendered one button per file is no longer needed.
+**Migration**: Name playlist JSON files with `name` fields matching one of the four moods: Ambient, Action, Foreboding, Triumphant.

--- a/openspec/changes/archive/2026-05-22-soundboard-redesign/tasks.md
+++ b/openspec/changes/archive/2026-05-22-soundboard-redesign/tasks.md
@@ -1,0 +1,35 @@
+## 1. Server — Local Audio Streaming
+
+- [x] 1.1 Add `GET /stream/:name` endpoint to `src/server.ts` that resolves the playlist, fetches the current track via `YouTubeService`, and pipes yt-dlp stdout as `audio/webm`
+- [x] 1.2 Track the active stream yt-dlp process in server state; kill it when a new `/stream` request arrives
+- [x] 1.3 Return 404 when no playlist matching `:name` exists
+- [x] 1.4 Add `POST /skip` passthrough behaviour for local mode (advance track index without starting Discord playback)
+
+## 2. Frontend — Mode Picker
+
+- [x] 2.1 Add mode picker markup to `index.html` (full-screen overlay with two buttons: Local Audio, Discord Bot)
+- [x] 2.2 Add mode picker styles to `style.css` (full-screen, centered, large tap targets)
+- [x] 2.3 Implement mode selection logic in `app.js`: store chosen mode in `sessionStorage` under `playback-mode`, hide picker, show soundboard
+- [x] 2.4 On load, skip picker and go straight to soundboard if `sessionStorage` already has a mode
+- [x] 2.5 Show active mode label in the soundboard header (e.g., small chip: "Local Audio" or "Discord Bot")
+
+## 3. Frontend — Four Fixed Mood Buttons
+
+- [x] 3.1 Replace dynamic grid rendering in `app.js` with four hardcoded buttons: Ambient, Action, Foreboding, Triumphant
+- [x] 3.2 Update `style.css` for 2×2 grid layout with large tap targets (min 120px height)
+- [x] 3.3 Remove the `/playlists` fetch call and `loadPlaylists()` function from `app.js`
+- [x] 3.4 Add error state style for mood buttons (red flash when server returns an error for that mood)
+
+## 4. Frontend — Mode-Aware Playback Controls
+
+- [x] 4.1 In `app.js`, add a hidden `<audio>` element to `index.html` for local playback
+- [x] 4.2 Route tap events based on mode: Local Audio → set `audio.src = /stream/:name` and call `audio.play()`; Discord → `POST /play/:name`
+- [x] 4.3 Route pause/resume based on mode: Local Audio → `audio.pause()` / `audio.play()`; Discord → `POST /pause` / `POST /resume`
+- [x] 4.4 Route skip based on mode: Local Audio → `POST /skip` then refresh `audio.src`; Discord → `POST /skip` as before
+- [x] 4.5 SSE updates from `/status` continue to drive the now-playing strip in both modes
+
+## 5. Tests
+
+- [x] 5.1 Add server test for `GET /stream/:name` — valid playlist returns 200 with audio content type
+- [x] 5.2 Add server test for `GET /stream/:name` — unknown playlist returns 404
+- [x] 5.3 Add server test that a second `/stream` request kills the first yt-dlp process

--- a/openspec/specs/audio-mode-selection/spec.md
+++ b/openspec/specs/audio-mode-selection/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Mode picker shown on first load
+The UI SHALL display a full-screen mode picker before the soundboard when no mode has been selected in the current session.
+
+#### Scenario: Fresh page load
+- **WHEN** the page loads and no mode is stored in sessionStorage
+- **THEN** a mode picker screen is shown with two options: "Local Audio" and "Discord Bot"; the soundboard grid is not visible
+
+#### Scenario: Mode already selected
+- **WHEN** the page loads and a mode is stored in sessionStorage
+- **THEN** the mode picker is skipped and the soundboard is shown immediately
+
+### Requirement: User selects a mode
+The UI SHALL store the chosen mode and transition to the soundboard without a page reload.
+
+#### Scenario: Select Local Audio
+- **WHEN** the user taps "Local Audio"
+- **THEN** `local` is stored in sessionStorage under the key `playback-mode`, and the soundboard view replaces the mode picker
+
+#### Scenario: Select Discord Bot
+- **WHEN** the user taps "Discord Bot"
+- **THEN** `discord` is stored in sessionStorage under the key `playback-mode`, and the soundboard view replaces the mode picker
+
+### Requirement: Mode is visible in the soundboard
+The UI SHALL indicate the active mode somewhere in the soundboard so the user can confirm which mode is running.
+
+#### Scenario: Mode label displayed
+- **WHEN** the soundboard is visible
+- **THEN** a small label shows either "Local Audio" or "Discord Bot" indicating the current mode

--- a/openspec/specs/local-audio-playback/spec.md
+++ b/openspec/specs/local-audio-playback/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Server streams track audio over HTTP
+The server SHALL expose `GET /stream/:name` that pipes yt-dlp audio output for the named playlist's current track as a chunked HTTP response.
+
+#### Scenario: Valid playlist name
+- **WHEN** `GET /stream/:name` is requested with a known playlist name
+- **THEN** the server responds with `Content-Type: audio/webm`, status 200, and streams audio data until the track ends or the connection closes
+
+#### Scenario: Unknown playlist name
+- **WHEN** `GET /stream/:name` is requested with an unknown playlist name
+- **THEN** the server responds with status 404
+
+#### Scenario: New stream requested while one is active
+- **WHEN** a `/stream/:name` request arrives while a previous stream process is running
+- **THEN** the previous yt-dlp process is killed and a new stream begins for the new request
+
+### Requirement: Browser plays audio via native audio element in Local Audio mode
+In Local Audio mode, the UI SHALL use an `<audio>` element pointed at `/stream/:name` rather than calling `/play/:name`.
+
+#### Scenario: Tap mood button in Local Audio mode
+- **WHEN** the user taps a mood button and the active mode is Local Audio
+- **THEN** the browser sets the `<audio>` element's `src` to `/stream/:name` and calls `.play()`; no request is sent to `/play/:name`
+
+#### Scenario: Tap mood button in Discord mode
+- **WHEN** the user taps a mood button and the active mode is Discord
+- **THEN** `POST /play/:name` is sent as before; the `<audio>` element is not used
+
+### Requirement: Playback controls adapt to Local Audio mode
+In Local Audio mode, pause and resume SHALL use the browser's native audio API; skip SHALL request a new stream for the same playlist.
+
+#### Scenario: Pause in Local Audio mode
+- **WHEN** the user taps Pause and the active mode is Local Audio
+- **THEN** `audio.pause()` is called; no request is sent to `/pause`
+
+#### Scenario: Resume in Local Audio mode
+- **WHEN** the user taps Resume and the active mode is Local Audio
+- **THEN** `audio.play()` is called; no request is sent to `/resume`
+
+#### Scenario: Skip in Local Audio mode
+- **WHEN** the user taps Skip and the active mode is Local Audio
+- **THEN** `POST /skip` is sent to advance the server's track index, then the `<audio>` src is refreshed to `/stream/:name` to start the next track

--- a/openspec/specs/soundboard-ui/spec.md
+++ b/openspec/specs/soundboard-ui/spec.md
@@ -1,15 +1,15 @@
 ## ADDED Requirements
 
-### Requirement: Mood grid displays all available playlists
-The UI SHALL display one button per playlist returned by `GET /playlists`, arranged in a responsive grid.
+### Requirement: Mood grid displays four fixed mood buttons
+The UI SHALL display exactly four fixed mood buttons — Ambient, Action, Foreboding, Triumphant — arranged in a 2×2 grid, regardless of what playlist files exist on disk.
 
-#### Scenario: Playlists loaded
-- **WHEN** the page loads and `GET /playlists` returns results
-- **THEN** each playlist is shown as a labelled button using its `name` field; buttons are large enough to tap comfortably on a phone (min 64px height)
+#### Scenario: Page loaded with mode selected
+- **WHEN** the soundboard view is shown after mode selection
+- **THEN** four large buttons are displayed: Ambient, Action, Foreboding, Triumphant; no dynamic loading from `/playlists` is required to render the grid
 
-#### Scenario: No playlists available
-- **WHEN** `GET /playlists` returns an empty array
-- **THEN** a message is displayed instructing the user to add playlist JSON files to the playlists directory
+#### Scenario: Missing playlist file
+- **WHEN** a mood button is tapped but no playlist JSON with a matching `name` exists on disk
+- **THEN** the server returns an error and the UI shows a brief error state on that button (e.g., red flash); the button does not disappear
 
 ### Requirement: Tapping a mood button switches playback immediately
 The UI SHALL send `POST /play/:name` when a mood button is tapped and reflect the active playlist visually.


### PR DESCRIPTION
…ming

- Add full-screen mode picker on load (Local Audio vs Discord Bot); Discord bot deferred until mode is explicitly selected
- Replace dynamic playlist grid with four fixed mood buttons (Ambient, Action, Foreboding, Triumphant) in a 2×2 layout
- Add GET /stream/:name to pipe yt-dlp audio directly to browser for Bluetooth/local speaker playback
- Add POST /disconnect-discord; mode chip in header re-opens picker and disconnects bot when leaving Discord mode
- Add PlaybackState.loadLocalMode / skipLocalMode for local playback without touching Discord; 7 new unit tests