### PR TITLE
Add buffering indicator with elapsed timer

### DIFF
--- a/client-app/src/playback-state.ts
+++ b/client-app/src/playback-state.ts
@@ -11,6 +11,7 @@ export interface NowPlayingState {
   trackIndex: number;
   totalTracks: number;
   playerStatus: string;
+  loading: boolean;
 }
 
 function shuffle<T>(arr: T[]): T[] {
@@ -32,6 +33,7 @@ export class PlaybackState {
   private sseClients = new Set<Response>();
   private pollInterval: ReturnType<typeof setInterval>;
   private advancing = false;
+  private loading = false;
 
   constructor(discord: DiscordService, cachePath?: string) {
     this.discord = discord;
@@ -79,6 +81,7 @@ export class PlaybackState {
     if (!this.tracks.length) return;
     const track = this.tracks[this.currentIndex]!;
     const query = `${track.name} ${track.artists.join(' ')}`;
+    this.loading = true;
     this.broadcast();
     try {
       const video = await this.yt.search(query);
@@ -86,8 +89,10 @@ export class PlaybackState {
       const stream = await this.yt.getAudioStream(video.url);
       const { stream: probed, type } = await demuxProbe(stream);
       const resource = createAudioResource(probed, { inputType: type, metadata: { title: video.title, id: video.id } });
+      this.loading = false;
       this.discord.playNow(resource);
     } catch {
+      this.loading = false;
     }
   }
 
@@ -139,6 +144,7 @@ export class PlaybackState {
       trackIndex: this.currentIndex,
       totalTracks: this.tracks.length,
       playerStatus: this.discord.getPlayerStatus() ?? 'idle',
+      loading: this.loading,
     };
   }
 

--- a/client-app/src/public/app.js
+++ b/client-app/src/public/app.js
@@ -2,6 +2,7 @@ const modePicker      = document.getElementById('mode-picker');
 const modeChip        = document.getElementById('mode-chip');
 const nowPlayingLabel = document.getElementById('now-playing-label');
 const nowPlayingTrack = document.getElementById('now-playing-track');
+const bufferingBadge  = document.getElementById('buffering-badge');
 const btnPauseResume  = document.getElementById('btn-pause-resume');
 const btnSkip         = document.getElementById('btn-skip');
 const localAudio      = document.getElementById('local-audio');
@@ -10,6 +11,30 @@ const STORAGE_KEY = 'playback-mode';
 let activeMode = null;
 let paused = false;
 let activePlaylistName = null;
+
+// --- Buffering timer ---
+
+let bufferingStart = null;
+let bufferingTimer = null;
+
+function startBufferingTimer() {
+  if (bufferingTimer) return;
+  bufferingStart = Date.now();
+  bufferingBadge.hidden = false;
+  bufferingBadge.textContent = 'Buffering 0s';
+  bufferingTimer = setInterval(() => {
+    const elapsed = Math.floor((Date.now() - bufferingStart) / 1000);
+    bufferingBadge.textContent = `Buffering ${elapsed}s`;
+  }, 1000);
+}
+
+function stopBufferingTimer() {
+  if (!bufferingTimer) return;
+  clearInterval(bufferingTimer);
+  bufferingTimer = null;
+  bufferingStart = null;
+  bufferingBadge.hidden = true;
+}
 
 // --- Mode picker ---
 
@@ -70,6 +95,12 @@ document.querySelectorAll('.mode-opt-btn').forEach(btn => {
 function setActiveButton(name) {
   document.querySelectorAll('.mood-btn').forEach(btn => {
     btn.classList.toggle('active', btn.dataset.name === name);
+  });
+}
+
+function setLoadingButton(name) {
+  document.querySelectorAll('.mood-btn').forEach(btn => {
+    btn.classList.toggle('loading', btn.dataset.name === name);
   });
 }
 
@@ -152,7 +183,19 @@ function updateUI(state) {
     nowPlayingTrack.textContent = '';
     btnPauseResume.hidden = true;
     btnSkip.hidden = true;
+    stopBufferingTimer();
+    setLoadingButton(null);
     return;
+  }
+
+  const isBuffering = state.loading || state.playerStatus === 'buffering';
+
+  if (isBuffering) {
+    startBufferingTimer();
+    setLoadingButton(activePlaylistName);
+  } else {
+    stopBufferingTimer();
+    setLoadingButton(null);
   }
 
   const isPaused = state.playerStatus === 'paused';
@@ -171,7 +214,7 @@ function updateUI(state) {
       ? `${state.track.name} — ${artists}`
       : state.track.name;
   } else {
-    nowPlayingTrack.textContent = 'Loading...';
+    nowPlayingTrack.textContent = '';
   }
 
   btnPauseResume.hidden = false;

--- a/client-app/src/public/index.html
+++ b/client-app/src/public/index.html
@@ -47,6 +47,7 @@
     <div class="now-playing-info">
       <div class="now-playing-label" id="now-playing-label">No playlist selected</div>
       <div class="now-playing-track" id="now-playing-track"></div>
+      <div class="buffering-badge" id="buffering-badge" hidden>Buffering 0s</div>
     </div>
     <div class="controls">
       <button id="btn-pause-resume" class="control-btn" hidden>⏸</button>

--- a/client-app/src/public/style.css
+++ b/client-app/src/public/style.css
@@ -7,7 +7,7 @@
   --text: #eaeaea;
   --text-muted: #8892a4;
   --active-glow: 0 0 12px rgba(233, 69, 96, 0.6);
-  --footer-height: 80px;
+  --footer-height: 88px;
 }
 
 * {
@@ -186,6 +186,17 @@ main {
   background: var(--surface-2);
 }
 
+.mood-btn.loading {
+  animation: loading-pulse 1.2s ease-in-out infinite;
+  border-color: var(--accent);
+  background: var(--surface-2);
+}
+
+@keyframes loading-pulse {
+  0%, 100% { box-shadow: 0 0 6px rgba(233, 69, 96, 0.3); }
+  50%       { box-shadow: 0 0 18px rgba(233, 69, 96, 0.7); }
+}
+
 .mood-btn.error {
   animation: error-flash 0.4s ease;
 }
@@ -234,6 +245,21 @@ footer#now-playing {
   overflow: hidden;
   text-overflow: ellipsis;
   margin-top: 0.2rem;
+}
+
+.buffering-badge {
+  color: var(--accent);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  margin-top: 0.2rem;
+  text-transform: uppercase;
+  animation: buffering-blink 1s ease-in-out infinite;
+}
+
+@keyframes buffering-blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.4; }
 }
 
 .controls {


### PR DESCRIPTION
## Summary
- Adds `loading: boolean` to `NowPlayingState` — set true while `playCurrentTrack()` is doing the YouTube search and stream fetch, false once Discord takes over
- Mood button pulses with a red glow while buffering (`.loading` CSS class)
- Footer shows a blinking `BUFFERING Xs` badge that counts up every second until audio starts
- Covers both phases: server-side loading (YouTube search/stream) via `state.loading`, and Discord's own buffering phase via `state.playerStatus === 'buffering'`

## Test plan
- [x] Tap a mood button — button should pulse and footer should show `Buffering 0s`, `Buffering 1s`, etc.
- [x] After audio starts, pulsing and badge stop
- [x] Tap a different mood mid-song — loading indicator reappears while the new track loads
- [x] Skip — loading indicator shows during the next track fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)